### PR TITLE
Rrin mcp pdf fix

### DIFF
--- a/kubernetes/mcp-servers/pdf/pdf-deployment.yaml
+++ b/kubernetes/mcp-servers/pdf/pdf-deployment.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       containers:
         - name: pdf-mcp-server
-          image: quay.io/rh-aiservices-bu/mcp-servers:pdf
+          #image: quay.io/rh-aiservices-bu/mcp-servers:pdf
+          image: quay.io/rusrin/rh-aiservices-bu:mcp-servers_pdf_v4
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -27,6 +28,12 @@ spec:
           env:
             - name: NPM_CONFIG_CACHE
               value: /tmp/.npm
+            - name: XDG_CONFIG_HOME
+              value: "/tmp/.chromium"
+            - name: XDG_CACHE_HOME
+              value: "/tmp/.chromium"
+            - name: M2P_OUTPUT_DIR
+              value: "/mcp_output"
           resources:
             limits:
               cpu: "500m"
@@ -34,3 +41,22 @@ spec:
             requests:
               cpu: "200m"
               memory: "256Mi"
+          volumeMounts:
+            - name: tmp-chrome-data
+              mountPath: /tmp/chrome-user-data
+            - name: tmp-crashpad
+              mountPath: /tmp/crashpad
+            - name: tmp-chromium
+              mountPath: /tmp/.chromium
+            - name: mcp-output
+              mountPath: /mcp_output
+      volumes:
+        - name: tmp-chrome-data
+          emptyDir: {}
+        - name: tmp-crashpad
+          emptyDir: {}
+        - name: tmp-chromium
+          emptyDir: {}
+        - name: mcp-output
+          emptyDir:
+            sizeLimit: 1Gi

--- a/kubernetes/reports-repo/kustomization.yaml
+++ b/kubernetes/reports-repo/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - pvc.yaml
+  - route.yaml
+  - service.yaml
+  - deployment.yaml
+  - configmap.yaml

--- a/kubernetes/reports-repo/service.yaml
+++ b/kubernetes/reports-repo/service.yaml
@@ -1,4 +1,4 @@
-sapiVersion: v1
+apiVersion: v1
 kind: Service
 metadata:
   labels:

--- a/mcp-servers/pdf/Containerfile
+++ b/mcp-servers/pdf/Containerfile
@@ -1,17 +1,37 @@
-FROM ghcr.io/puppeteer/puppeteer:latest
+FROM ghcr.io/puppeteer/puppeteer:24.8.2
 
 # Set working directory
 WORKDIR /app
 
-# Clone the markdown2pdf MCP repo
-RUN git clone https://github.com/2b3pro/markdown2pdf-mcp.git
-WORKDIR /app/markdown2pdf-mcp
+# Create required directories with proper permissions
+RUN mkdir -p /home/pptruser/.cache/puppeteer && \
+    mkdir -p /tmp/chrome-user-data && \
+    mkdir -p /tmp/crashpad && \
+    mkdir -p /app/markdown2pdf-mcp && \
+    chown -R pptruser:pptruser /home/pptruser/.cache/puppeteer && \
+    chown -R pptruser:pptruser /tmp/chrome-user-data && \
+    chown -R pptruser:pptruser /tmp/crashpad
 
-# Install dependencies and build
-RUN npm install && npm run build
+
+# Clone the markdown2pdf MCP repo
+RUN git clone https://github.com/2b3pro/markdown2pdf-mcp.git && \
+    cd markdown2pdf-mcp && \
+    git checkout 32c0dfa
+
+WORKDIR /app/markdown2pdf-mcp
+COPY  ./render.js /app/markdown2pdf-mcp/src/puppeteer/render.js
+
+# Install dependencies and build and remove extra chrome installation
+RUN npm install && npm run build && \
+    find /home/pptruser/.cache/puppeteer/chrome/ -mindepth 1 -maxdepth 1 \
+        ! -name 'linux-131.0.6778.204' -exec rm -rf {} +
 
 # Expose the server port (default is 8010)
 EXPOSE 8010
+
+# Set Puppeteer environment variables
+ENV PUPPETEER_EXECUTABLE_PATH=/home/pptruser/.cache/puppeteer/chrome/linux-131.0.6778.204/chrome-linux64/chrome
+ENV PUPPETEER_LAUNCH_ARGS="--no-sandbox --disable-crashpad --user-data-dir=/tmp/chrome-user-data --crashpad-database=/tmp/crashpad"
 
 # Start the MCP server with supergateway
 CMD ["npx", "-y", "supergateway", "--stdio", "node build/index.js", "--port", "8010"]

--- a/mcp-servers/pdf/render.js
+++ b/mcp-servers/pdf/render.js
@@ -1,0 +1,150 @@
+import puppeteer from 'puppeteer';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import os from 'os';
+
+const CHROME_VERSION = '131.0.6778.204';
+
+function getPlatformPath() {
+  const platform = process.platform;
+  const arch = os.arch();
+  
+  if (platform === 'darwin') {
+    return arch === 'arm64' 
+      ? `mac_arm-${CHROME_VERSION}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`
+      : `mac-${CHROME_VERSION}/chrome-mac/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`;
+  }
+  if (platform === 'linux') {
+    return `linux-${CHROME_VERSION}/chrome-linux/chrome`;
+  }
+  if (platform === 'win32') {
+    return `win64-${CHROME_VERSION}/chrome-win/chrome.exe`;
+  }
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+async function renderPDF({
+  htmlPath,
+  pdfPath,
+  runningsPath,
+  cssPath,
+  highlightCssPath,
+  paperFormat,
+  paperOrientation,
+  paperBorder,
+  renderDelay,
+  loadTimeout
+}) {
+  const args = process.env.PUPPETEER_LAUNCH_ARGS
+    ? process.env.PUPPETEER_LAUNCH_ARGS.split(' ')
+    : [
+        '--no-sandbox',
+        '--disable-crashpad',
+        '--user-data-dir=/tmp/chrome-user-data',
+        '--crashpad-database=/tmp/crashpad',
+      ];
+
+  const executablePath =
+    process.env.PUPPETEER_EXECUTABLE_PATH ||
+    path.join(
+      os.homedir(),
+      '.cache',
+      'puppeteer',
+      'chrome',
+      getPlatformPath(),
+      'chrome-linux64',
+      'chrome'
+    );
+
+  console.log("Launching Puppeteer with executablePath:", executablePath);
+  console.log("Using args:", args);
+
+  // Attempt to launch Chromium with the specified path and args
+  let browser;
+  try {
+    browser = await puppeteer.launch({
+      headless: true,
+      executablePath,
+      args,
+      product: 'chrome',
+    });
+  } catch (err) {
+    console.error("Error message:", err.message);
+    throw new Error(`Could not launch Chromium from ${executablePath}: ${err.message}`);
+  }
+
+  console.log("Successfully launched Chrome!");
+
+  try {
+    const page = await browser.newPage();
+    
+    // Set viewport
+    await page.setViewport({
+      width: 1200,
+      height: 1600
+    });
+
+    // Handle timeout
+    const timeout = setTimeout(() => {
+      throw new Error('Timeout loading HTML content');
+    }, loadTimeout);
+
+    // Load the HTML file
+    await page.goto(`file://${htmlPath}`, {
+      waitUntil: 'networkidle0',
+      timeout: loadTimeout
+    });
+    clearTimeout(timeout);
+
+    // Import runnings (header/footer)
+    const runnings = await import(fileURLToPath(`file://${runningsPath}`));
+
+    // Add CSS if provided
+    if (cssPath) {
+      await page.addStyleTag({ path: cssPath });
+    }
+    
+    if (highlightCssPath) {
+      await page.addStyleTag({ path: highlightCssPath });
+    }
+
+    // Wait for specified delay
+    await new Promise(resolve => setTimeout(resolve, renderDelay));
+
+    // Force repaint to ensure proper rendering
+    await page.evaluate(() => {
+      document.body.style.transform = 'scale(1)';
+      return document.body.offsetHeight;
+    });
+
+    // Get watermark text if present
+    const watermarkText = '' //await page.evaluate(() => {
+//      const watermark = document.querySelector('.watermark');
+//      return watermark ? watermark.textContent : '';
+//    });
+
+    // Generate PDF
+    await page.pdf({
+      path: pdfPath,
+      format: paperFormat,
+      landscape: paperOrientation === 'landscape',
+      margin: {
+        top: paperBorder,
+        right: paperBorder,
+        bottom: paperBorder,
+        left: paperBorder
+      },
+      printBackground: true,
+      displayHeaderFooter: !!watermarkText,
+      headerTemplate: watermarkText ? runnings.default.header(watermarkText) : '',
+      footerTemplate: watermarkText ? runnings.default.footer(watermarkText) : '',
+      preferCSSPageSize: true
+    });
+
+    return true;
+  } finally {
+    await browser.close();
+  }
+}
+
+export default renderPDF;


### PR DESCRIPTION
- minor fix in repo update (missing kustomization and typo in kind of service)

- bugfix for pdf mcp servers where it could not generate pdf 

before (in UI):
🛠 I was unable to generate a PDF document for you. This is because I don't have the capability to directly interact with your system or access external tools such as Google Chrome. However, I can provide you with the markdown content that can be used to create a PDF document.

after (in UI):
🛠 The PDF document has been successfully created with a summary of the support cases and the account status for ACME. The document includes the title "ACME Support Cases and Account Status" and a table summarizing the support cases, along with a brief description of the account status. The PDF is saved in the directory /mcp_output/ with the filename ACME_Support_Cases.pdf.
If exec in container you should see the file in /mcp_output directory

also, puppeteer and mcp server version are fixed (with image tag and sha)

The root issue: mcp server did not chromium in sandbox and also pdf mcp deployment miss proper env variables.
The image is pushed to public repo image: quay.io/rusrin/rh-aiservices-bu:mcp-servers_pdf_v4, feel free to push to proper quay.io/rh-aiservices-bu/mcp-servers:pdf